### PR TITLE
Rename config file, add guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ Ensure you have the following installed:
 
 ## Usage
 
-Before running the project, make sure to configure the Discord webhook URL. Open the `all_products.go` file and set the `DiscordWebhookURL` variable
+Before running the program, make sure to configure the Discord webhook URL. 
+
+1. Environment variable `DISCORD_WEBHOOK_URL` set on the command line.
+2. Config file `/etc/unifi-monitor.yml`, with the key `DISCORD_WEBHOOK_URL:`
+
 
 Run the project:
 

--- a/all_products.go
+++ b/all_products.go
@@ -342,7 +342,7 @@ func readEnv(key, defaultValue string) string {
 		return value
 	}
 
-	configFile := "/etc/config.yml"
+	configFile := "/etc/unifi-monitor.yml"
 	data, err := os.ReadFile(configFile)
 	if err == nil {
 		var config Config


### PR DESCRIPTION
The config file shouldn't be named simply "config.yml" when it lives in the system configuration place. Or, if it is, it should live in a sub-folder named to indicate the owning application.

I've renamed the expected file to "/etc/unifi-monitor.yml", and added some usage guidance to the README.md.